### PR TITLE
source: make source files ReadSeekers

### DIFF
--- a/diagnostic/emitter.go
+++ b/diagnostic/emitter.go
@@ -85,19 +85,24 @@ func (e *writerEmitter) printRegion(d Diagnostic) error {
 		return nil
 	}
 
-	line := d.Line()
-	maxLine := lines[len(lines)-1].Num
+	line := int(d.Line())
+	startLine := int(d.StartLine())
+	maxLine := startLine + len(lines) - 1
 	lastLineDigits := int64(len(fmt.Sprint(maxLine)))
 	lineFormat := "\n" + `%-` + fmt.Sprint(lastLineDigits) + "d | "
 
 	buf.WriteRune('\n')
-	for _, l := range lines {
-		buf.WriteString(fmt.Sprintf(lineFormat, l.Num))
-		buf.WriteString(l.Content)
-		if l.Num == line {
+	for i, l := range lines {
+		buf.WriteString(fmt.Sprintf(lineFormat, startLine+i))
+		buf.WriteString(l)
+		if startLine+i == line {
 			buf.WriteRune('\n')
-			for i := int64(0); i < d.Column()+3-1+lastLineDigits; i++ {
-				buf.WriteRune(' ')
+			for j := int64(0); j < d.Column()+3-1+lastLineDigits; j++ {
+				if e.colors {
+					buf.WriteString(d.Severity().Color()("-"))
+				} else {
+					buf.WriteRune('-')
+				}
 			}
 
 			if e.colors {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -41,6 +41,7 @@ func NewSession(d *diagnostic.Diagnoser, cm *source.CodeMap) *Session {
 func ParseFile(fileName string, src io.Reader, mode ParseMode) (f *ast.File, err error) {
 	// TODO(erizocosmico): correctly set root
 	cm := source.NewCodeMap(source.NewFsLoader("."))
+	defer cm.Close()
 	sess := NewSession(
 		diagnostic.NewDiagnoser(cm, diagnostic.Stderr(true, true)),
 		cm,

--- a/source/loader.go
+++ b/source/loader.go
@@ -1,7 +1,8 @@
 package source
 
 import (
-	"io/ioutil"
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -13,7 +14,7 @@ type Loader interface {
 	AbsPath(string) string
 	// Load reads the source code of the file at the given relative project
 	// path.
-	Load(string) ([]byte, error)
+	Load(string) (io.ReadSeeker, error)
 }
 
 // FsLoader is a loader from file system.
@@ -34,15 +35,14 @@ func (l *FsLoader) AbsPath(path string) string {
 }
 
 // Load retrieves the source code of the file at the given path.
-func (l *FsLoader) Load(path string) ([]byte, error) {
+func (l *FsLoader) Load(path string) (io.ReadSeeker, error) {
 	p := l.AbsPath(path)
 	f, err := os.Open(p)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 
-	return ioutil.ReadAll(f)
+	return f, nil
 }
 
 // MemLoader is a loader that works in memory. It is intended for test
@@ -67,9 +67,9 @@ func (l *MemLoader) AbsPath(path string) string {
 }
 
 // Load retrieves the content of the given path.
-func (l *MemLoader) Load(path string) ([]byte, error) {
+func (l *MemLoader) Load(path string) (io.ReadSeeker, error) {
 	if s, ok := l.files[path]; ok {
-		return []byte(s), nil
+		return bytes.NewReader([]byte(s)), nil
 	}
 
 	return nil, os.ErrNotExist


### PR DESCRIPTION
Because now all source files are ReadSeekers, we no longer have to
keep them all in memory, just have the file and then dynamically
seek to the region start position and read the region we want.
As a result of this, regions are no longer line spans, but offset
spans in the source file.